### PR TITLE
fix undefined reference to `pthread_setname_np' error

### DIFF
--- a/src/consumer.c
+++ b/src/consumer.c
@@ -93,7 +93,7 @@ consumer_start(void *arg) {
 
     char name[24] = {0};
     sprintf(name, "consumer-%d", ctx->index + 1);
-    pthread_setname_np(pthread_self(), name);
+    prctl(PR_SET_NAME, name, 0, 0, 0);
 
     loop = malloc(sizeof(uv_loop_t));
     uv_loop_init(loop);

--- a/src/consumer.c
+++ b/src/consumer.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <sys/prctl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>


### PR DESCRIPTION
fix `undefined reference to 'pthread_setname_np'` error on some system when compile.
